### PR TITLE
feat: make OpenAI model and temperature configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,7 @@ OPENAI_API_KEY=sk-???
 REQUIRE_AUTH=True
 AUTH_USERNAME=manager
 AUTH_PASSWORD=secret
+
+# OpenAI Model Configuration
+OPENAI_MODEL=gpt-3.5-turbo     # Available models: gpt-3.5-turbo, gpt-3.5-turbo-0125, gpt-4, gpt-4-0125
+OPENAI_TEMPERATURE=0.2         # Range: 0.0 to 2.0, lower = more focused, higher = more creative

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Concept Explainer is a project that leverages the OpenAI API via Langchain to ex
   - [Web Interface](#web-interface)
 - [Implementation Notes](#implementation-notes)
 - [Markdown Reader](#markdown-reader)
+- [Model Configuration](#model-configuration)
 
 ## Installation
 
@@ -101,6 +102,46 @@ python md_reader.py "saved_concepts/black_holes_2023-07-10-15-30-00.md"
 ```
 
 This command will print the content of the specified Markdown file in the console.
+
+## Model Configuration
+
+The application supports different OpenAI models and settings through environment variables:
+
+### Available Models
+
+Configure the model using `OPENAI_MODEL` in your `.env` file:
+
+- `gpt-3.5-turbo` (default) - Good balance of performance and cost
+- `gpt-3.5-turbo-0125` - Latest GPT-3.5 version with improvements
+- `gpt-4` - Higher quality but more expensive
+- `gpt-4-0125` - Latest GPT-4 version with improvements
+
+Example:
+```bash
+OPENAI_MODEL=gpt-4
+```
+
+### Temperature Setting
+
+Control the randomness of responses using `OPENAI_TEMPERATURE` in your `.env` file:
+
+- Range: 0.0 to 2.0
+- Default: 0.2
+- Lower values (e.g., 0.2) = More focused, consistent responses
+- Higher values (e.g., 0.8) = More creative, varied responses
+
+Example:
+```bash
+OPENAI_TEMPERATURE=0.5
+```
+
+### Cost Considerations
+
+Different models have different pricing:
+- GPT-3.5 models are more cost-effective
+- GPT-4 models provide higher quality but at higher cost
+
+Please review OpenAI's pricing at: https://openai.com/pricing
 
 ## License
 


### PR DESCRIPTION
Closes #8 

## Changes Made

- Added environment variables for model configuration:
  - `OPENAI_MODEL` - Select which model to use
  - `OPENAI_TEMPERATURE` - Control response randomness

- Added validation for model settings:
  - List of supported models
  - Temperature range validation (0.0 to 2.0)
  - Helpful error messages

- Updated documentation:
  - Added Model Configuration section to README
  - Documented available models and their tradeoffs
  - Added temperature setting guidelines
  - Added cost considerations

## Testing Done

- [x] Tested with default settings (gpt-3.5-turbo, temp=0.2)
- [x] Verified error messages for invalid model names
- [x] Verified error messages for invalid temperature values
- [x] Checked documentation accuracy and completeness

## Example Usage

```bash
# Use GPT-4 with slightly more creative responses
OPENAI_MODEL=gpt-4
OPENAI_TEMPERATURE=0.5

# Use latest GPT-3.5 with very focused responses
OPENAI_MODEL=gpt-3.5-turbo-0125
OPENAI_TEMPERATURE=0.1
``` 